### PR TITLE
20241111/fix param bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 0.16.1
+
+- fix bug
+  - become: `Context.QueryParam()` & `Context.PathParam()` only return string

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Simple Web Framework of GoLang
 
 ```sh
-go get github.com/poteto0/poteto@v0.16.0
+go get github.com/poteto0/poteto@v0.16.1
 go mod tidy
 ```
 

--- a/context.go
+++ b/context.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/goccy/go-json"
 	"github.com/poteto0/poteto/constant"
+	"github.com/poteto0/poteto/utils"
 )
 
 type Context interface {
@@ -17,8 +18,8 @@ type Context interface {
 	WriteHeader(code int)
 	SetQueryParam(queryParams url.Values)
 	SetParam(paramType string, paramUnit ParamUnit)
-	PathParam(key string) any
-	QueryParam(key string) any
+	PathParam(key string) (string, bool)
+	QueryParam(key string) (string, bool)
 	Bind(object any) error
 	GetPath() string
 	SetPath(path string)
@@ -81,11 +82,7 @@ func (ctx *context) SetQueryParam(queryParams url.Values) {
 	for key, value := range queryParams {
 		var paramUnit ParamUnit
 
-		if len(value) == 1 { // not array
-			paramUnit = ParamUnit{key, value[0]}
-		} else {
-			paramUnit = ParamUnit{key, value}
-		}
+		paramUnit = ParamUnit{key, utils.StrArrayToStr(value)}
 
 		ctx.SetParam(constant.PARAM_TYPE_QUERY, paramUnit)
 	}
@@ -95,19 +92,13 @@ func (ctx *context) SetParam(paramType string, paramUnit ParamUnit) {
 	ctx.httpParams.AddParam(paramType, paramUnit)
 }
 
-func (ctx *context) PathParam(key string) any {
+func (ctx *context) PathParam(key string) (string, bool) {
 	key = constant.PARAM_PREFIX + key
-	if val := ctx.httpParams.GetParam(constant.PARAM_TYPE_PATH, key); val != nil {
-		return val
-	}
-	return nil
+	return ctx.httpParams.GetParam(constant.PARAM_TYPE_PATH, key)
 }
 
-func (ctx *context) QueryParam(key string) any {
-	if val := ctx.httpParams.GetParam(constant.PARAM_TYPE_QUERY, key); val != nil {
-		return val
-	}
-	return nil
+func (ctx *context) QueryParam(key string) (string, bool) {
+	return ctx.httpParams.GetParam(constant.PARAM_TYPE_QUERY, key)
 }
 
 func (ctx *context) Bind(object any) error {

--- a/context.go
+++ b/context.go
@@ -80,9 +80,11 @@ func (ctx *context) SetQueryParam(queryParams url.Values) {
 	}
 
 	for key, value := range queryParams {
-		var paramUnit ParamUnit
+		if len(value) == 0 {
+			continue
+		}
 
-		paramUnit = ParamUnit{key, utils.StrArrayToStr(value)}
+		paramUnit := ParamUnit{key, utils.StrArrayToStr(value)}
 
 		ctx.SetParam(constant.PARAM_TYPE_QUERY, paramUnit)
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -52,13 +52,13 @@ func TestQueryParam(t *testing.T) {
 	queryParams := req.URL.Query()
 	ctx.SetQueryParam(queryParams)
 
-	queryParam1 := ctx.QueryParam("hello")
+	queryParam1, _ := ctx.QueryParam("hello")
 	if queryParam1 != "world" {
 		t.Errorf("Cannot Get Query Param")
 	}
 
-	queryParam2 := ctx.QueryParam("unknown")
-	if queryParam2 != nil {
+	queryParam2, _ := ctx.QueryParam("unknown")
+	if queryParam2 != "" {
 		t.Errorf("Cannot Get nil If Unknown key")
 	}
 }
@@ -73,20 +73,25 @@ func TestPathParam(t *testing.T) {
 	ctx.SetParam(constant.PARAM_TYPE_PATH, ParamUnit{key: ":id", value: "1"})
 
 	tests := []struct {
-		name     string
-		key      string
-		expected any
+		name        string
+		key         string
+		expected    string
+		expected_ok bool
 	}{
-		{"Can get PathParam", "id", "1"},
-		{"If unexpected key", "unexpected", nil},
+		{"Can get PathParam", "id", "1", true},
+		{"If unexpected key", "unexpected", "", false},
 	}
 
 	for _, it := range tests {
 		t.Run(it.name, func(t *testing.T) {
-			param := ctx.PathParam(it.key)
+			param, ok := ctx.PathParam(it.key)
 
 			if param != it.expected {
 				t.Errorf("Unmatched")
+			}
+
+			if ok != it.expected_ok {
+				t.Errorf("unmatched")
 			}
 		})
 

--- a/http_param.go
+++ b/http_param.go
@@ -6,32 +6,36 @@ import (
 
 type ParamUnit struct {
 	key   string
-	value any
+	value string
 }
 
 type httpParam struct {
-	params map[string]map[string]any
+	params map[string]map[string]string
 }
 
 type HttpParam interface {
-	GetParam(paramType, key string) any
+	GetParam(paramType, key string) (string, bool)
 	AddParam(paramType string, paramUnit ParamUnit)
 }
 
 func NewHttpParam() HttpParam {
-	params := make(map[string]map[string]any, 4)
+	params := make(map[string]map[string]string, 4)
 
 	httpParam := &httpParam{
 		params: params,
 	}
 
-	httpParam.params[constant.PARAM_TYPE_PATH] = make(map[string]any)
-	httpParam.params[constant.PARAM_TYPE_QUERY] = make(map[string]any)
+	httpParam.params[constant.PARAM_TYPE_PATH] = make(map[string]string)
+	httpParam.params[constant.PARAM_TYPE_QUERY] = make(map[string]string)
 	return httpParam
 }
 
-func (hp *httpParam) GetParam(paramType, key string) any {
-	return hp.params[paramType][key]
+func (hp *httpParam) GetParam(paramType, key string) (string, bool) {
+	val := hp.params[paramType][key]
+	if val != "" {
+		return val, true
+	}
+	return "", false
 }
 
 func (hp *httpParam) AddParam(paramType string, paramUnit ParamUnit) {

--- a/http_param_test.go
+++ b/http_param_test.go
@@ -12,8 +12,28 @@ func TestAddAndGetParam(t *testing.T) {
 	pu := ParamUnit{"key", "value"}
 	hp.AddParam(constant.PARAM_TYPE_PATH, pu)
 
-	value := hp.GetParam(constant.PARAM_TYPE_PATH, "key")
-	if value != "value" {
-		t.Errorf("Don't Work")
+	tests := []struct {
+		name         string
+		key          string
+		expected_val string
+		expected_ok  bool
+	}{
+		{"test ok case", "key", "value", true},
+		{"test unexpected", "unexpected", "", false},
 	}
+
+	for _, it := range tests {
+		t.Run(it.name, func(t *testing.T) {
+			value, ok := hp.GetParam(constant.PARAM_TYPE_PATH, it.key)
+
+			if value != it.expected_val {
+				t.Errorf("Don't Work")
+			}
+
+			if ok != it.expected_ok {
+				t.Errorf("Unmatched")
+			}
+		})
+	}
+
 }

--- a/utils/math.go
+++ b/utils/math.go
@@ -13,3 +13,15 @@ func SliceEqual[T comparable](as, bs []T) bool {
 
 	return true
 }
+
+// EX:) []string{"hello", "world"} -> hello,world
+func StrArrayToStr(targets []string) string {
+	var val_str string
+	for i, target := range targets {
+		val_str += target
+		if i != len(targets)-1 {
+			val_str += ","
+		}
+	}
+	return val_str
+}

--- a/utils/math_test.go
+++ b/utils/math_test.go
@@ -24,3 +24,24 @@ func TestSliceEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestStrArrayToStr(t *testing.T) {
+	tests := []struct {
+		name     string
+		targets  []string
+		expected string
+	}{
+		{"Test 1 len array", []string{"hello"}, "hello"},
+		{"Test multi len array", []string{"hello", "world", "!!"}, "hello,world,!!"},
+	}
+
+	for _, it := range tests {
+		t.Run(it.name, func(t *testing.T) {
+			result := StrArrayToStr(it.targets)
+
+			if result != it.expected {
+				t.Errorf("Unmatched")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## version
it will be `>=0.16.1`.

## change
- add changelog
- `Context.PathParam()` & `Context.QueryParam()` only return tuple ( string, bool )

## Issue
https://github.com/poteto0/poteto/issues/40