### PR TITLE
20241119/logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # 0.x.x
 
+## 0.18.x
+
+### 0.18.0
+
+- `Poteto` has SetLogger
+- You can call logger.XXX() from context
+
 ## 0.17.x
 
 ## 0.17.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 0.18.0
 
 - `Poteto` has SetLogger
-- You can call logger.XXX() from context
+- You can call ctx.Logger().XXX() from context
 
 ## 0.17.x
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Simple Web Framework of GoLang
 
 ```sh
-go get github.com/poteto0/poteto@v0.17.2
+go get github.com/poteto0/poteto@v0.18.0
 go mod tidy
 ```
 

--- a/app_test.go
+++ b/app_test.go
@@ -11,6 +11,10 @@ func TestServeHTTP(t *testing.T) {
 	p := New()
 	p.GET("/users", getAllUserForTest)
 	p.GET("/users/:id", getAllUserForTestById)
+	logger := func(msg string) {
+		return
+	}
+	p.SetLogger(logger)
 
 	tests := []struct {
 		name         string

--- a/context.go
+++ b/context.go
@@ -33,6 +33,7 @@ type Context interface {
 	RegisterTrustIPRange(ranges *net.IPNet)
 	GetIPFromXFFHeader() (string, error)
 	Reset(w http.ResponseWriter, r *http.Request)
+	SetLogger(logger any)
 }
 
 type context struct {
@@ -42,6 +43,7 @@ type context struct {
 	path       string
 	httpParams HttpParam
 	store      map[string]any
+	logger     any
 	lock       sync.RWMutex
 
 	// Method
@@ -177,4 +179,8 @@ func (ctx *context) Reset(w http.ResponseWriter, r *http.Request) {
 	ctx.response = NewResponse(w)
 	ctx.httpParams = NewHttpParam()
 	ctx.store = make(map[string]any)
+}
+
+func (ctx *context) SetLogger(logger any) {
+	ctx.logger = logger
 }

--- a/context.go
+++ b/context.go
@@ -34,6 +34,7 @@ type Context interface {
 	GetIPFromXFFHeader() (string, error)
 	Reset(w http.ResponseWriter, r *http.Request)
 	SetLogger(logger any)
+	Logger() any
 }
 
 type context struct {
@@ -183,4 +184,8 @@ func (ctx *context) Reset(w http.ResponseWriter, r *http.Request) {
 
 func (ctx *context) SetLogger(logger any) {
 	ctx.logger = logger
+}
+
+func (ctx *context) Logger() any {
+	return ctx.logger
 }

--- a/context_test.go
+++ b/context_test.go
@@ -150,3 +150,18 @@ func TestGetIPFromXFFHeaderByContext(t *testing.T) {
 		t.Errorf("Not matched")
 	}
 }
+
+func TestGetLogger(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "https://example.com", strings.NewReader(userJSON))
+	ctx := NewContext(w, req).(*context)
+
+	logger := func(msg string) {
+		return
+	}
+	ctx.SetLogger(logger)
+
+	if ctx.Logger() == nil {
+		t.Errorf("Unmatched")
+	}
+}

--- a/poteto_test.go
+++ b/poteto_test.go
@@ -79,3 +79,19 @@ func TestRun(t *testing.T) {
 		})
 	}
 }
+
+func TestSetLogger(t *testing.T) {
+	p := New().(*poteto)
+	logger := func(msg string) {
+		return
+	}
+
+	if p.logger != nil {
+		t.Error("Unmatched")
+	}
+
+	p.SetLogger(logger)
+	if p.logger == nil {
+		t.Errorf("Unmatched")
+	}
+}


### PR DESCRIPTION
## Change
- `Poteto` has SetLogger
- You can call ctx.Logger().XXX() from context

## How to use
- your logger interface
```go
type logger struct {
  log *logrus.Logger
}

type Logger interface {
  Info(args ...any)
}

func NewLogger() Logger {
  log := logrus.New()
  log.Out = os.Stdout
  return &logger{
    log: log,
  }
}

func(l *logger) Info(args ...any) {
  ...
}
```

- SetLogger
```go
p := New()
logger := NewLogger()
p.SetLogger(logger)
```

- And you can call from context
```go
func handler(ctx poteto.Context) error {
  ctx.Logger().Info("logged")
}
```

## Issue
#76 