### PR TITLE
`Poteto.Run()` internal call http.Server#Serve instead of http.ListenAndServe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # 0.x.x
 
+## 0.20.x
+
+### 0.20.0
+
+- CHANGE: `Poteto.Run()` internal call http.Server#Serve instead of http.ListenAndServe
+  You can use your protocol such as udp
+- CHANGE: `Poteto.Stop(stdContext)` stop server
+
 ## 0.19.x
 
 ### 0.19.1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Simple Web Framework of GoLang
 
 ```sh
-go get github.com/poteto0/poteto@v0.19.1
+go get github.com/poteto0/poteto@v0.20.1
 go mod tidy
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Simple Web Framework of GoLang
 
 ```sh
-go get github.com/poteto0/poteto@v0.20.1
+go get github.com/poteto0/poteto@v0.20.0
 go mod tidy
 ```
 

--- a/poteto.go
+++ b/poteto.go
@@ -118,15 +118,15 @@ func (p *poteto) applyMiddleware(middlewares []MiddlewareFunc, handler HandlerFu
 
 func (p *poteto) Run(addr string) error {
 	p.startupMutex.Lock()
-	defer p.startupMutex.Unlock()
 
 	if err := p.setupServer(); err != nil {
+		p.startupMutex.Unlock()
 		return err
 	}
 
 	utils.PotetoPrint("server is available at http://localhost" + addr + "\n")
 
-	p.startupMutex.Unlock() // Unlock before serve
+	p.startupMutex.Unlock()
 	return p.Server.Serve(p.Listener)
 }
 
@@ -153,9 +153,9 @@ func (p *poteto) setupServer() error {
 // It internally calls `http.Server#Shutdown()`.
 func (p *poteto) Stop(ctx stdContext.Context) error {
 	p.startupMutex.Lock()
-	defer p.startupMutex.Unlock()
 
 	if err := p.Server.Shutdown(ctx); err != nil {
+		p.startupMutex.Unlock()
 		return err
 	}
 

--- a/poteto.go
+++ b/poteto.go
@@ -3,6 +3,7 @@ package poteto
 import (
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 
 	stdContext "context"
@@ -118,6 +119,10 @@ func (p *poteto) applyMiddleware(middlewares []MiddlewareFunc, handler HandlerFu
 
 func (p *poteto) Run(addr string) error {
 	p.startupMutex.Lock()
+
+	if !strings.Contains(addr, constant.PARAM_PREFIX) {
+		addr = constant.PARAM_PREFIX + addr
+	}
 
 	if err := p.setupServer(); err != nil {
 		p.startupMutex.Unlock()

--- a/poteto_option.go
+++ b/poteto_option.go
@@ -1,9 +1,11 @@
 package poteto
 
 type PotetoOption struct {
-	WithRequestId bool `yaml:"with_request_id"`
+	WithRequestId   bool   `yaml:"with_request_id"`
+	ListenerNetwork string `yaml:"listener_network"`
 }
 
 var DefaultPotetoOption = PotetoOption{
-	WithRequestId: true,
+	WithRequestId:   true,
+	ListenerNetwork: "tcp",
 }

--- a/poteto_test.go
+++ b/poteto_test.go
@@ -1,6 +1,7 @@
 package poteto
 
 import (
+	stdContext "context"
 	"testing"
 	"time"
 )
@@ -56,15 +57,20 @@ func TestRun(t *testing.T) {
 		port1 string
 		port2 string
 	}{
-		//{"Test :8080", ":8080", ""},
+		{"Test :8080", ":8080", ""},
 		{"Test 8080", "8080", ""},
-		//{"Test collision panic", ":8080", ":8080"},
+		{"Test collision panic", ":8080", ":8080"},
 	}
 
 	for _, it := range tests {
 		t.Run(it.name, func(t *testing.T) {
 			done := make(chan struct{})
 			go func() {
+				defer func() {
+					if err := p.Stop(stdContext.Background()); err != nil {
+						t.Errorf("Unmatched")
+					}
+				}()
 				p.Run(it.port1)
 				if it.port2 != "" {
 					p.Run(it.port2)

--- a/poteto_test.go
+++ b/poteto_test.go
@@ -69,12 +69,21 @@ func TestRunAndStop(t *testing.T) {
 				errChan <- p.Run(it.port1)
 			}()
 
+			errChan2 := make(chan error)
+			if it.port2 != "" {
+				go func() {
+					errChan2 <- p.Run(it.port2)
+				}()
+			}
+
 			select {
 			case <-time.After(500 * time.Millisecond):
 				if err := p.Stop(stdContext.Background()); err != nil {
 					t.Errorf("Unmatched")
 				}
 			case <-errChan:
+				return
+			case <-errChan2:
 				return
 			}
 		})


### PR DESCRIPTION
## Change
- CHANGE: `Poteto.Run()` internal call http.Server#Serve instead of http.ListenAndServe
  You can use your protocol such as udp
- CHANGE: `Poteto.Stop(stdContext)` stop server

## How to use
```go
import (
  ...
  stdContext "context"
)

func main() {
  p := poteto.New()
  
  errChan := make(chan error)
  go func() {
    errChan <- p.Run(":8080")
  } ()

  select {
  case err := <- errChan:
    fmt.Errorf("Error occurr & stop Server: %v", err)
    if stopErr := p.Stop(stdContext.Background()); stopErr != nil {
      fmt.Errorf("Error occurr during stopping server: %v", err)
    }
  }
}
```

## Issue
https://github.com/poteto0/poteto/issues/83