### PR TITLE
`Context.RealIP()` return RealIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # 0.x.x
 
+## 0.22.x
+
+### 0.22.0
+
+- FEATURE: `Context.RealIP()` return realIp
+- CHANGE: `Context.GetIPFromXFFHeader()` return just X-Forwarded-For
+- DOCUMENT: update some document
+
 ## 0.21.x
 
 ### 0.21.0

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ func UserHandler(ctx poteto.Context) error {
 }
 
 func UserIdHandler(ctx poteto.Context) error {
+	name, _ := ctx.PathParam("name")
 	user := User{
-		Name: ctx.PathParam("id")
+		Name: name
 	}
 	return ctx.JSON(http.StatusOK, user)
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Simple Web Framework of GoLang
 
 ```sh
-go get github.com/poteto0/poteto@v0.21.0
+go get github.com/poteto0/poteto@v0.22.0
 go mod tidy
 ```
 

--- a/constant/constant.go
+++ b/constant/constant.go
@@ -31,4 +31,5 @@ const (
 	HEADER_CONTENT_LENGTH        string = "Content-Length"
 	HEADER_X_REQUEST_ID          string = "X-Request-Id"
 	HEADER_X_FORWARDED_FOR       string = "X-Forwarded-For"
+	HEADER_X_REAL_IP             string = "X-Real-Ip"
 )

--- a/context.go
+++ b/context.go
@@ -39,6 +39,7 @@ type Context interface {
 	GetRemoteIP() (string, error)
 	RegisterTrustIPRange(ranges *net.IPNet)
 	GetIPFromXFFHeader() (string, error)
+	RealIP() (string, error)
 	Reset(w http.ResponseWriter, r *http.Request)
 	SetLogger(logger any)
 	Logger() any
@@ -207,6 +208,10 @@ func (ctx *context) RegisterTrustIPRange(ranges *net.IPNet) {
 
 func (ctx *context) GetIPFromXFFHeader() (string, error) {
 	return ctx.ipHandler.GetIPFromXFFHeader(ctx)
+}
+
+func (ctx *context) RealIP() (string, error) {
+	return ctx.ipHandler.RealIP(ctx)
 }
 
 // using same binder

--- a/context_test.go
+++ b/context_test.go
@@ -190,6 +190,51 @@ func TestGetIPFromXFFHeaderByContext(t *testing.T) {
 	}
 }
 
+func TestRealIP(t *testing.T) {
+	tests := []struct {
+		name        string
+		headerKey   string
+		headerValue string
+		expected    string
+	}{
+		{
+			"Get from Real Ip",
+			constant.HEADER_X_REAL_IP,
+			"11.0.0.1",
+			"11.0.0.1",
+		},
+		{
+			"Get from XFF",
+			constant.HEADER_X_FORWARDED_FOR,
+			"11.0.0.1",
+			"11.0.0.1",
+		},
+		{
+			"Get from RemoteAddr",
+			"",
+			"",
+			"192.0.2.1",
+		},
+	}
+
+	for _, it := range tests {
+		t.Run(it.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/test", nil)
+			if it.headerKey != "" {
+				req.Header.Set(it.headerKey, it.headerValue)
+			}
+			ctx := NewContext(w, req).(*context)
+
+			ipString, _ := ctx.RealIP()
+			if ipString[0:8] != it.expected[0:8] {
+				t.Errorf(ipString)
+				t.Errorf("Not matched")
+			}
+		})
+	}
+}
+
 func TestGetLogger(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "https://example.com", strings.NewReader(userJSON))

--- a/ip_handler_test.go
+++ b/ip_handler_test.go
@@ -52,3 +52,51 @@ func TestGetIPFromXFFHeader(t *testing.T) {
 		t.Errorf("Not matched")
 	}
 }
+
+func TestGetRealIP(t *testing.T) {
+	iph := &ipHandler{}
+
+	tests := []struct {
+		name        string
+		headerKey   string
+		headerValue string
+		expected    string
+	}{
+		{
+			"Get from Real Ip",
+			constant.HEADER_X_REAL_IP,
+			"11.0.0.1",
+			"11.0.0.1",
+		},
+		{
+			"Get from XFF",
+			constant.HEADER_X_FORWARDED_FOR,
+			"11.0.0.1",
+			"11.0.0.1",
+		},
+		{
+			"Get from RemoteAddr",
+			"",
+			"",
+			"192.0.2.1",
+		},
+	}
+
+	for _, it := range tests {
+		t.Run(it.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/test", nil)
+			if it.headerKey != "" {
+				req.Header.Set(it.headerKey, it.headerValue)
+			}
+			ctx := NewContext(w, req).(*context)
+
+			ipString, _ := iph.RealIP(ctx)
+			if ipString[0:8] != it.expected[0:8] {
+				t.Errorf(ipString)
+				t.Errorf("Not matched")
+			}
+		})
+	}
+
+}

--- a/ip_handler_test.go
+++ b/ip_handler_test.go
@@ -98,5 +98,4 @@ func TestGetRealIP(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -38,6 +38,7 @@ type RequestLoggerConfig struct {
 	HasRequestID     bool
 	HasUserAgent     bool
 	HasRemoteIP      bool
+	HasRealIP        bool
 	HasHost          bool
 	HasContentLength bool
 	OpenHeaders      []string
@@ -55,6 +56,7 @@ var DefaultRequestLoggerConfig = RequestLoggerConfig{
 	HasRequestID:     true,
 	HasUserAgent:     true,
 	HasRemoteIP:      true,
+	HasRealIP:        true,
 	HasHost:          true,
 	HasContentLength: true,
 	OpenHeaders:      []string{},
@@ -71,6 +73,7 @@ type RequestLoggerValues struct {
 	RequestId     string
 	UserAgent     string
 	RemoteIP      string
+	RealIP        string
 	Host          string
 	ContentLength string
 	Headers       map[string][]string
@@ -119,6 +122,13 @@ func RequestLoggerWithConfig(config RequestLoggerConfig) poteto.MiddlewareFunc {
 
 			if config.HasRemoteIP {
 				rlv.RemoteIP, err = ctx.GetRemoteIP()
+				if err != nil {
+					panic(err)
+				}
+			}
+
+			if config.HasRealIP {
+				rlv.RealIP, err = ctx.RealIP()
 				if err != nil {
 					panic(err)
 				}


### PR DESCRIPTION
## Change
- FEATURE: `Context.RealIP()` return realIp
- CHANGE: `Context.GetIPFromXFFHeader()` return just X-Forwarded-For
- DOCUMENT: update some document

## How to use
```go
func handler(ctx poteto.Context) error {
  ip, _ := ctx.RealIP()
}
```

## Algo

1. get from X-Forwarded-For
2. get from X-Real-IP
3. get from RemoteAddr

## Version
it will be included `>=0.22.0`

## Issue
#53 